### PR TITLE
Change effective precision of [DateUtils toJulian] from float to double

### DIFF
--- a/suncalc/utils/DateUtils.m
+++ b/suncalc/utils/DateUtils.m
@@ -15,7 +15,7 @@ const int J1970 = 2440588;
 const int J2000 = 2451545;
 
 + (double)toJulian:(NSDate*)date {
-    return (float)[date timeIntervalSince1970] / DAY_SECONDS - 0.5 + J1970;
+    return (double)[date timeIntervalSince1970] / DAY_SECONDS - 0.5 + J1970;
 }
 
 + (NSDate*)fromJulian:(double)j {


### PR DESCRIPTION
[NSDate timeIntervalSince1970] returns a double, and [DateUtils
toJulian] was casting it a float, stripping off valuable
precision. This was causing [SunCalc
getSunPositionDate:latitude:longitude:] to return a Sun position that
would stay fixed for many seconds at a time, and then suddenly jump
half a degree when it eventually changed.

In test code, the Sun altitude remained unchanged at 8.76209 degrees
for many seconds, and then later changed to 9.29653, where it stayed
for an extended period.

This behavior occurred only on the device, and not in the simulator.
